### PR TITLE
Fix specialization variable typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,8 @@
     let currentLevelXP = 0;
     let xpToNextLevel = 40;
     const BASE_REROLLS_PER_CHOICE = 3;
-    let chosenizations = [];
+    // Track chosen class specializations for the current run
+    let chosenSpecializations = [];
 
     function getCssVar(varName) {
         return getComputedStyle(document.documentElement).getPropertyValue(varName).trim();


### PR DESCRIPTION
## Summary
- correct typo `chosenizations` -> `chosenSpecializations`
- add comment clarifying purpose

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6840030efd4483228ec7ae4c1e5e5b6f