### PR TITLE
Fix explosion opacity decay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1952,7 +1952,7 @@
                 ctx.fillStyle = effect.color;
                 ctx.beginPath();
                 ctx.arc(effect.x, effect.y, Math.max(0, effect.currentRadius), 0, Math.PI * 2);
-                ctx.globalAlpha = Math.max(0, effect.duration / (effect.creationTime + effect.durationMs - Date.now() + 1)); // +1 to avoid div by zero
+                ctx.globalAlpha = Math.max(0, effect.duration / effect.durationMs);
                 ctx.fill();
                 ctx.globalAlpha = 1.0;
             }


### PR DESCRIPTION
## Summary
- adjust drawActiveEffects transparency calculation to rely on durationMs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684004e4552c83229cf6198d2021cf77