### PR TITLE
Implement meta progression and pause overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,18 @@
         <h1>Nova Core: Genesis</h1>
         <p>A Basic Retro Shooter.</p>
         <button id="startGameButton">Start Game</button>
+        <div class="menu-row">
+            <button id="openMetaShopButton">Meta Shop</button>
+            <button id="openScoreboardButton">Scoreboard</button>
+        </div>
+        <div class="menu-row">
+            <label for="difficultySelect">Difficulty:</label>
+            <select id="difficultySelect">
+                <option value="1">Normal</option>
+                <option value="0.7">Easy</option>
+                <option value="1.5">Hard</option>
+            </select>
+        </div>
     </div>
 
     <div id="gameScreen" class="screen">
@@ -29,6 +41,13 @@
                 <button id="rerollButtonElement" disabled>Reroll (<span id="rerollsAvailableDisplay">0</span>)</button>
             </div>
         </div>
+        <div id="pauseOverlay" class="hidden pause-overlay">
+            <h3>Paused</h3>
+            <p>Time: <span id="pauseTimeDisplay">0</span></p>
+            <p>Score: <span id="pauseScoreDisplay">0</span></p>
+            <button id="resumeButton">Resume</button>
+            <button id="quitButton">Quit</button>
+        </div>
     </div>
 
     <div id="gameOverScreen" class="screen">
@@ -36,6 +55,19 @@
         <p>Final Score: <span id="finalScoreDisplay"></span></p>
         <p>Level Reached: <span id="finalLevelDisplay"></span></p>
         <button id="restartGameButton">Restart Run</button>
+    </div>
+
+    <div id="scoreboardScreen" class="screen">
+        <h2>Scoreboard</h2>
+        <ul id="scoreboardList"></ul>
+        <button id="backToMenuButton">Back</button>
+    </div>
+
+    <div id="metaShopScreen" class="screen">
+        <h2>Meta Shop</h2>
+        <p>Meta Points: <span id="metaPointsDisplay">0</span></p>
+        <div id="metaUpgrades"></div>
+        <button id="backFromShopButton">Back</button>
     </div>
 
 <script src="main.js"></script>

--- a/style.css
+++ b/style.css
@@ -135,3 +135,9 @@
         #gameOverScreen h2 { color: #ff4757; text-shadow: 2px 2px 0px #8a2323; }
         #gameOverScreen p { color: var(--text-alt-color); font-size: 0.9em; }
 
+        .menu-row { margin-top: 10px; display: flex; gap: 8px; justify-content: center; align-items: center; }
+        .pause-overlay { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background-color: var(--secondary-color); padding: 20px; border: 2px solid var(--primary-color); z-index: 150; text-align: center; }
+        #scoreboardList { list-style: none; padding: 0; }
+        #scoreboardList li { margin-bottom: 6px; }
+        .synergy-hint { box-shadow: 0 0 6px 2px gold; }
+


### PR DESCRIPTION
## Summary
- add meta shop and scoreboard menus in HTML
- style pause overlay, menu rows, scoreboard list and synergy hints
- track meta points, scoreboard and run stats in main.js
- implement pause/resume, meta shop, scoreboard, and difficulty selector
- highlight potential synergy upgrades

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684008f286ec8322bcd9b5ba483295dd