### PR TITLE
Add achievements and events with upgrade limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
             <div>Score: <span id="scoreDisplay">0</span></div>
             <div class="xp-bar-container"><div id="xpBar"></div><span id="xpProgressText">0/100 XP</span></div>
             <div>HP: <span id="hpDisplay">100</span>/<span id="maxHpDisplay">100</span></div>
+            <div>Upgrades: <span id="upgradeCountDisplay">0</span>/5</div>
         </div>
         <div id="augmentationChoicePanel" class="hidden">
             <h3 id="augmentationPanelTitle">Choose Upgrade!</h3>
@@ -45,8 +46,11 @@
             <h3>Paused</h3>
             <p>Time: <span id="pauseTimeDisplay">0</span></p>
             <p>Score: <span id="pauseScoreDisplay">0</span></p>
+            <p>Level: <span id="pauseLevelDisplay">1</span></p>
+            <p>Kills: <span id="pauseKillsDisplay">0</span></p>
             <button id="resumeButton">Resume</button>
             <button id="quitButton">Quit</button>
+            <button id="pauseMainMenuButton">Main Menu</button>
         </div>
     </div>
 
@@ -55,6 +59,7 @@
         <p>Final Score: <span id="finalScoreDisplay"></span></p>
         <p>Level Reached: <span id="finalLevelDisplay"></span></p>
         <button id="restartGameButton">Restart Run</button>
+        <button id="gameOverMenuButton">Back to Main Menu</button>
     </div>
 
     <div id="scoreboardScreen" class="screen">
@@ -69,6 +74,8 @@
         <div id="metaUpgrades"></div>
         <button id="backFromShopButton">Back</button>
     </div>
+
+    <div id="achievementToast" class="hidden achievement-toast"></div>
 
 <script src="main.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -139,5 +139,12 @@
         .pause-overlay { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background-color: var(--secondary-color); padding: 20px; border: 2px solid var(--primary-color); z-index: 150; text-align: center; }
         #scoreboardList { list-style: none; padding: 0; }
         #scoreboardList li { margin-bottom: 6px; }
-        .synergy-hint { box-shadow: 0 0 6px 2px gold; }
+.synergy-hint { box-shadow: 0 0 6px 2px gold; }
+
+.achievement-toast {
+    position: absolute; top: 10px; right: 10px;
+    background: rgba(0,0,0,0.8); color: #fff; padding: 8px 12px;
+    border: 2px solid var(--accent-color); z-index: 200;
+    font-size: 0.75em; box-shadow: 0 0 5px var(--accent-color);
+}
 


### PR DESCRIPTION
## Summary
- show chosen upgrade count in HUD and toast for achievements
- add local achievement tracking to unlock classes
- limit upgrades to five per run
- implement simple random circle event granting extra projectiles
- include basic endless boss and stats from earlier

## Testing
- `node -e "require('./main.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684014372b788322810feb743913ce1c