### PR TITLE
Add more meta upgrades and raise upgrade limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             <div>Score: <span id="scoreDisplay">0</span></div>
             <div class="xp-bar-container"><div id="xpBar"></div><span id="xpProgressText">0/100 XP</span></div>
             <div>HP: <span id="hpDisplay">100</span>/<span id="maxHpDisplay">100</span></div>
-            <div>Upgrades: <span id="upgradeCountDisplay">0</span>/5</div>
+            <div>Upgrades: <span id="upgradeCountDisplay">0</span>/10</div>
         </div>
         <div id="augmentationChoicePanel" class="hidden">
             <h3 id="augmentationPanelTitle">Choose Upgrade!</h3>

--- a/style.css
+++ b/style.css
@@ -162,3 +162,17 @@
     text-align: center;
 }
 
+#difficultySelect {
+    background-color: var(--secondary-color);
+    border: 2px solid var(--primary-color);
+    color: var(--primary-color);
+    padding: 5px;
+    font-family: var(--font-main);
+    margin-left: 6px;
+}
+
+#difficultySelect option {
+    background-color: var(--secondary-color);
+    color: var(--primary-color);
+}
+


### PR DESCRIPTION
## Summary
- allow up to 10 upgrades per run
- style difficulty selector to match the retro UI
- expand meta shop with several new upgrades
- apply meta upgrade bonuses to the player

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_68401c90bafc8322b63d067b00abf15d