### PR TITLE
Add zone events and power-ups

### DIFF
--- a/style.css
+++ b/style.css
@@ -188,3 +188,13 @@
     width: 100%;
     box-sizing: border-box;
 }
+
+.meta-upgrade {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 4px;
+}
+.meta-upgrade span:first-child {
+    flex: 1;
+}


### PR DESCRIPTION
## Summary
- introduce permanent zone rewards and temporary power-up items
- spawn random power-ups on enemy defeat
- improve Meta Shop layout for clarity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684026bd30a48322b35878abf56e53fd