### PR TITLE
Fix meta shop layout

### DIFF
--- a/main.js
+++ b/main.js
@@ -2425,9 +2425,9 @@
             costSpan.textContent = `${cost} MP`;
 
             row.appendChild(nameSpan);
-            row.appendChild(buyBtn);
-            row.appendChild(ownedSpan);
             row.appendChild(costSpan);
+            row.appendChild(ownedSpan);
+            row.appendChild(buyBtn);
 
             metaUpgradesContainer.appendChild(row);
         });

--- a/style.css
+++ b/style.css
@@ -192,10 +192,14 @@
 .meta-upgrade {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 4px;
+    gap: 6px;
     width: 100%;
+    justify-content: flex-start;
 }
 .meta-upgrade span:first-child {
     flex: 1;
+}
+.meta-upgrade span:not(:first-child) {
+    min-width: 60px;
+    text-align: center;
 }


### PR DESCRIPTION
## Summary
- reorder DOM insertion in updateMetaShopUI so each row lists name, cost, owned, buy button
- tweak `.meta-upgrade` styles for better alignment

## Testing
- `node test-meta.js` *(manual jsdom script)*

------
https://chatgpt.com/codex/tasks/task_e_68403fd30e708322b1e7e740d3b6e4a0