### PR TITLE
Implement class selection overlay and power-up notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,6 @@
                 <option value="1.5">Hard</option>
             </select>
         </div>
-        <div class="menu-row">
-            <label for="startingSpecSelect">Specialization:</label>
-            <select id="startingSpecSelect"></select>
-        </div>
     </div>
 
     <div id="gameScreen" class="screen">


### PR DESCRIPTION
## Summary
- remove specialization dropdown from the main menu
- ask for specialization after starting the game
- show a toast when picking up power-ups and pull them towards the player

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684042d9e2a48322ba1b7a4d8df521cf