### PR TITLE
Fix enemy explosion location

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -30,7 +30,7 @@ export function checkBulletCollisions(enemies, onHit) {
       const e = enemies[j];
       const dist = Math.hypot(b.x - e.x, b.y - e.y);
       if (dist < e.size / 2) {
-        onHit(j);
+        onHit(e, j);
         bullets.splice(i, 1);
         break;
       }

--- a/main.js
+++ b/main.js
@@ -35,10 +35,10 @@ function gameLoop() {
   player.update(dt, keys, mouse, bullets);
   updateBullets(dt, canvas);
   updateEnemies(dt, player, canvas);
-  checkBulletCollisions(enemies, idx => {
+  checkBulletCollisions(enemies, (enemy, idx) => {
     enemies.splice(idx, 1);
     score += 10;
-    createExplosion(player.x, player.y);
+    createExplosion(enemy.x, enemy.y);
   });
   updateExplosions(dt);
 


### PR DESCRIPTION
## Summary
- fix wrong explosion position when an enemy is defeated

## Testing
- `node --check main.js`
- `node --check effects.js`

------
https://chatgpt.com/codex/tasks/task_e_684052db19508322a88323ccef1ae40d