### PR TITLE
Add enemy health, XP orbs and upgrade system

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -30,8 +30,11 @@ export function checkBulletCollisions(enemies, onHit) {
       const e = enemies[j];
       const dist = Math.hypot(b.x - e.x, b.y - e.y);
       if (dist < e.size / 2) {
-        onHit(e, j);
+        e.hp -= b.damage || 10;
         bullets.splice(i, 1);
+        if (e.hp <= 0) {
+          onHit(e, j);
+        }
         break;
       }
     }

--- a/enemies.js
+++ b/enemies.js
@@ -8,7 +8,8 @@ export function spawnEnemy(canvas, level = 1) {
   else if (side === 1) { x = canvas.width + size; y = Math.random() * canvas.height; }
   else if (side === 2) { x = Math.random() * canvas.width; y = canvas.height + size; }
   else { x = -size; y = Math.random() * canvas.height; }
-  enemies.push({ x, y, size, speed: 50 + level * 10, hp: 10 + level * 5 });
+  const hp = 10 + level * 5;
+  enemies.push({ x, y, size, speed: 50 + level * 10, hp, maxHp: hp });
 }
 
 export function updateEnemies(dt, player, canvas) {
@@ -28,10 +29,23 @@ export function updateEnemies(dt, player, canvas) {
 }
 
 export function drawEnemies(ctx) {
-  ctx.fillStyle = '#ff4757';
   enemies.forEach(e => {
+    // enemy body
+    ctx.fillStyle = '#ff4757';
     ctx.beginPath();
     ctx.arc(e.x, e.y, e.size / 2, 0, Math.PI * 2);
     ctx.fill();
+
+    // hp bar
+    const barWidth = e.size;
+    const barHeight = 4;
+    const barX = e.x - barWidth / 2;
+    const barY = e.y - e.size / 2 - 8;
+    ctx.fillStyle = '#5a0000';
+    ctx.fillRect(barX, barY, barWidth, barHeight);
+    ctx.fillStyle = '#ff0000';
+    ctx.fillRect(barX, barY, (e.hp / e.maxHp) * barWidth, barHeight);
+    ctx.strokeStyle = '#000000';
+    ctx.strokeRect(barX, barY, barWidth, barHeight);
   });
 }

--- a/main.js
+++ b/main.js
@@ -1,6 +1,8 @@
 import { Player } from './player.js';
 import { enemies, spawnEnemy, updateEnemies, drawEnemies } from './enemies.js';
 import { bullets, explosions, updateBullets, drawBullets, checkBulletCollisions, updateExplosions, drawExplosions, createExplosion } from './effects.js';
+import { xpOrbs, spawnXPOrb, updateXPOrbs, drawXPOrbs } from './xp.js';
+import { showUpgradeMenu } from './upgrades.js';
 import { updateUI } from './ui.js';
 
 const canvas = document.getElementById('gameCanvas');
@@ -39,15 +41,23 @@ function gameLoop() {
     enemies.splice(idx, 1);
     score += 10;
     createExplosion(enemy.x, enemy.y);
+    spawnXPOrb(enemy.x, enemy.y, 10);
   });
+  updateXPOrbs(dt, player);
   updateExplosions(dt);
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   player.draw(ctx);
   drawEnemies(ctx);
   drawBullets(ctx);
+  drawXPOrbs(ctx);
   drawExplosions(ctx);
   updateUI(player, score);
+
+  if (player.needsUpgrade) {
+    player.needsUpgrade = false;
+    showUpgradeMenu(player);
+  }
 
   requestAnimationFrame(gameLoop);
 }
@@ -58,9 +68,12 @@ function startGame() {
   enemies.length = 0;
   bullets.length = 0;
   explosions.length = 0;
+  xpOrbs.length = 0;
   lastSpawn = 0;
   lastTime = performance.now();
   showScreen('gameScreen');
+  const panel = document.getElementById('augmentationChoicePanel');
+  if (panel) panel.classList.add('hidden');
   requestAnimationFrame(gameLoop);
 }
 

--- a/player.js
+++ b/player.js
@@ -7,9 +7,15 @@ export class Player {
     this.color = '#00FFFF';
     this.hp = 100;
     this.maxHp = 100;
+    this.xp = 0;
+    this.xpToNext = 50;
+    this.level = 1;
     this.speed = 200; // pixels per second
+    this.damage = 10;
+    this.fireRate = 300; // ms between shots
     this.angle = -Math.PI / 2;
     this.lastShot = 0;
+    this.needsUpgrade = false;
   }
 
   update(dt, keys, mouse, bullets) {
@@ -28,13 +34,14 @@ export class Player {
 
     this.angle = Math.atan2(mouse.y - this.y, mouse.x - this.x);
 
-    if ((keys[' '] || mouse.down) && Date.now() - this.lastShot > 300) {
+    if ((keys[' '] || mouse.down) && Date.now() - this.lastShot > this.fireRate) {
       bullets.push({
         x: this.x,
         y: this.y,
         angle: this.angle,
         speed: 400,
-        owner: 'player'
+        owner: 'player',
+        damage: this.damage
       });
       this.lastShot = Date.now();
     }
@@ -55,5 +62,15 @@ export class Player {
     ctx.closePath();
     ctx.fill();
     ctx.restore();
+  }
+
+  gainXp(amount) {
+    this.xp += amount;
+    while (this.xp >= this.xpToNext) {
+      this.xp -= this.xpToNext;
+      this.level += 1;
+      this.xpToNext = Math.floor(this.xpToNext * 1.2);
+      this.needsUpgrade = true;
+    }
   }
 }

--- a/ui.js
+++ b/ui.js
@@ -1,7 +1,15 @@
 export const levelDisplay = document.getElementById('levelDisplay');
 export const scoreDisplay = document.getElementById('scoreDisplay');
+export const xpBar = document.getElementById('xpBar');
+export const xpProgressText = document.getElementById('xpProgressText');
+export const hpDisplay = document.getElementById('hpDisplay');
+export const maxHpDisplay = document.getElementById('maxHpDisplay');
 
 export function updateUI(player, score) {
   if (levelDisplay) levelDisplay.textContent = player.level || 1;
   if (scoreDisplay) scoreDisplay.textContent = score;
+  if (xpBar) xpBar.style.width = ((player.xp / player.xpToNext) * 100) + '%';
+  if (xpProgressText) xpProgressText.textContent = `${player.xp}/${player.xpToNext} XP`;
+  if (hpDisplay) hpDisplay.textContent = Math.floor(player.hp);
+  if (maxHpDisplay) maxHpDisplay.textContent = player.maxHp;
 }

--- a/upgrades.js
+++ b/upgrades.js
@@ -1,0 +1,33 @@
+export const upgradeOptions = [
+  { name: 'Increase Damage', apply: p => { p.damage += 5; } },
+  { name: 'Increase Max HP', apply: p => { p.maxHp += 20; p.hp += 20; } },
+  { name: 'Faster Fire Rate', apply: p => { p.fireRate = Math.max(100, p.fireRate - 50); } },
+  { name: 'Increase Speed', apply: p => { p.speed += 30; } }
+];
+
+function pickRandom(arr, n) {
+  const copy = arr.slice();
+  const res = [];
+  for (let i = 0; i < n && copy.length > 0; i++) {
+    const idx = Math.floor(Math.random() * copy.length);
+    res.push(copy.splice(idx, 1)[0]);
+  }
+  return res;
+}
+
+export function showUpgradeMenu(player) {
+  const panel = document.getElementById('augmentationChoicePanel');
+  const choicesDiv = document.getElementById('augmentationChoices');
+  panel.classList.remove('hidden');
+  choicesDiv.innerHTML = '';
+  const options = pickRandom(upgradeOptions, 3);
+  options.forEach(opt => {
+    const btn = document.createElement('button');
+    btn.textContent = opt.name;
+    btn.addEventListener('click', () => {
+      opt.apply(player);
+      panel.classList.add('hidden');
+    });
+    choicesDiv.appendChild(btn);
+  });
+}

--- a/xp.js
+++ b/xp.js
@@ -1,0 +1,36 @@
+export const xpOrbs = [];
+
+export function spawnXPOrb(x, y, amount) {
+  xpOrbs.push({ x, y, amount, radius: 5, vx: (Math.random() - 0.5) * 60, vy: (Math.random() - 0.5) * 60 });
+}
+
+export function updateXPOrbs(dt, player) {
+  for (let i = xpOrbs.length - 1; i >= 0; i--) {
+    const o = xpOrbs[i];
+    o.x += o.vx * (dt / 1000);
+    o.y += o.vy * (dt / 1000);
+    o.vx *= 0.98;
+    o.vy *= 0.98;
+    const dx = player.x - o.x;
+    const dy = player.y - o.y;
+    const dist = Math.hypot(dx, dy);
+    if (dist < player.radius + o.radius) {
+      player.gainXp(o.amount);
+      xpOrbs.splice(i, 1);
+      continue;
+    }
+    if (dist > 0) {
+      o.x += (dx / dist) * 30 * (dt / 1000);
+      o.y += (dy / dist) * 30 * (dt / 1000);
+    }
+  }
+}
+
+export function drawXPOrbs(ctx) {
+  ctx.fillStyle = '#40E0D0';
+  xpOrbs.forEach(o => {
+    ctx.beginPath();
+    ctx.arc(o.x, o.y, o.radius, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}


### PR DESCRIPTION
## Summary
- add `xp.js` to spawn and collect experience orbs
- add `upgrades.js` with simple upgrade choices
- give enemies HP and draw health bars
- bullets now do damage and enemies die only at 0 HP
- player tracks XP/levels and can gain upgrades
- show XP and HP in UI

## Testing
- `node --check xp.js`
- `node --check upgrades.js`
- `node --check enemies.js`
- `node --check player.js`
- `node --check effects.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68405489724c832294e43aa50a000f59